### PR TITLE
Fix neofetch installing aborting

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ installer() {
     rm 00-header 10-help-text 50-landscape-sysinfo 50-motd-news 90-updates-available 91-release-upgrade 92-unattended-upgrades 97-overlayroot
     echo "# Successfully removed default text. Installing NeoFetch..."
     sleep 2s
-    sudo apt install neofetch
+    apt install neofetch -y
     sudo bash -c $'echo "neofetch" >> /etc/profile.d/mymotd.sh && chmod +x /etc/profile.d/mymotd.sh'
     warning "Successfully installed NeoFetch on your machine and put it as your MOTD."
 }


### PR DESCRIPTION
Installing neofetch aborts the installation, fixed by using "-y" in the apt-get

![image](https://user-images.githubusercontent.com/51095261/135766321-9ea6fc02-23d2-433f-98c8-5586d03161ec.png)
